### PR TITLE
Renames

### DIFF
--- a/pyEcoHAB/__init__.py
+++ b/pyEcoHAB/__init__.py
@@ -4,8 +4,8 @@ sample_data_path = os.path.join(ecohab_loc, '..', 'data')
 
 from .Loader import Loader, Merger
 from .ExperimentConfigFile import ExperimentConfigFile
-from .analiza_friends import get_in_cohort_sociability
+from .analiza_friends import get_incohort_sociability
 from .analiza_friends import get_solitude
-from .cage_visits import get_all_visits
+from .cage_visits import get_activity
 from .tube_dominance import get_tube_dominance
 from .mouse_speed import get_following, resample_single_phase

--- a/pyEcoHAB/__init__.py
+++ b/pyEcoHAB/__init__.py
@@ -5,7 +5,7 @@ sample_data_path = os.path.join(ecohab_loc, '..', 'data')
 from .Loader import Loader, Merger
 from .ExperimentConfigFile import ExperimentConfigFile
 from .analiza_friends import get_in_cohort_sociability
-from .analiza_friends import get_mouse_alone
+from .analiza_friends import get_solitude
 from .cage_visits import get_all_visits
 from .tube_dominance import get_tube_dominance
 from .mouse_speed import get_following, resample_single_phase

--- a/pyEcoHAB/analiza_friends.py
+++ b/pyEcoHAB/analiza_friends.py
@@ -132,7 +132,7 @@ def get_solitude(ehs, cf, res_dir=None, prefix=None):
     for phase, sec in enumerate(phases):
         times = cf.gettime(sec)
         data = utils.prepare_data(ehs, mice, times)
-        for i in range(1,5):
+        for i in range(1, 5):
             alone = mouse_alone(data, i)
             for j, mouse in enumerate(mice):
                 output[i-1, j, phase] = alone[mouse]

--- a/pyEcoHAB/analiza_friends.py
+++ b/pyEcoHAB/analiza_friends.py
@@ -206,7 +206,7 @@ def prepare_fnames_and_totals(ehs, cf, prefix,
     return phases, total_time, data, fnames, get_data
 
 
-def get_in_cohort_sociability(ehs, cf, res_dir=None,
+def get_incohort_sociability(ehs, cf, res_dir=None,
                               prefix=None, which_phases=None,
                               remove_mouse=None):
     if prefix is None:

--- a/pyEcoHAB/analiza_friends.py
+++ b/pyEcoHAB/analiza_friends.py
@@ -121,7 +121,7 @@ def mice_together(data_mice, m1, m2, total_time):
 
 
 
-def get_mouse_alone(ehs, cf, res_dir=None, prefix=None):
+def get_solitude(ehs, cf, res_dir=None, prefix=None):
     if prefix is None:
         prefix = ehs.prefix
     if res_dir is None:

--- a/pyEcoHAB/cage_visits.py
+++ b/pyEcoHAB/cage_visits.py
@@ -63,7 +63,7 @@ def get_all_visits(ehs, cf, binsize, cages=None,
     mice = utils.get_mice(ehs.mice, remove_mouse)
     add_info_mice = utils.add_info_mice_filename(remove_mouse)
     if cages is None:
-        cages = {'1': "A", '3': "C", '2': "B", '4': "D"}
+        cages = {1: "A", 3: "C", 2: "B", 4: "D"}
     headers = {i:basic for i in cages.keys()}
     data = {c:{0:{},1:{}} for c in cages.keys()}
     data['mice'] = mice
@@ -77,7 +77,7 @@ def get_all_visits(ehs, cf, binsize, cages=None,
         for address in cages.keys():
             visit_data = calculate_visits_and_durations(ehs_data,
                                                         mice,
-                                                        cages[address],
+                                                        address,
                                                         t_start,
                                                         t_end,
                                                         binsize)

--- a/pyEcoHAB/cage_visits.py
+++ b/pyEcoHAB/cage_visits.py
@@ -45,7 +45,7 @@ def calculate_visits_and_durations(data, mice, address, t_start, t_end, binsize)
     return visits, durations, all_visits
 
 
-def get_all_visits(ehs, cf, binsize, cages=None,
+def get_activity(ehs, cf, binsize, cages=None,
                    res_dir=None, prefix=None,
                    remove_mouse=None, headers=None):
     if prefix is None:

--- a/pyEcoHAB/write_to_file.py
+++ b/pyEcoHAB/write_to_file.py
@@ -142,7 +142,7 @@ def write_csv_tables(results, phases, mice, main_directory, dirname, fname, pref
         f.write('\n')
     f.close()
 
-def write_csv_alone(alone, phases, mice, main_directory, prefix, labels=["1", "2", "3", "4"],  header='Mice alone in chamber %s\n', fname='mouse_alone_%s.csv', directory="mouse_alone"):
+def write_csv_alone(alone, phases, mice, main_directory, prefix, labels=["A", "B", "C", "D"],  header='Mice alone in chamber %s\n', fname='mouse_alone_%s.csv', directory="solitude"):
     directory = utils.check_directory(main_directory, directory)
     fname =  os.path.join(directory, fname % prefix)
     try:


### PR DESCRIPTION
Rename get_mouse alone to get_solitude, get_all_visits to get_activity and get_in_cohort_sociability to get_incohort_sociability, which is in agreement with Alicja Puścian's specification.
Fix errors in get_activity.
