### PR TITLE
Duplicate activity in social_approach dict

### DIFF
--- a/pyEcoHAB/cage_visits.py
+++ b/pyEcoHAB/cage_visits.py
@@ -101,3 +101,5 @@ def get_activity(ehs, cf, binsize, cages=None,
                                  prefix, add_info_mice)
     save_data_cvs(data, phases, mice, bin_labels, fname, res_dir,
                   cages, headers)
+    save_data_cvs(data, phases, mice, bin_labels, fname, res_dir,
+                  cages, headers, target_dir="social_approach")


### PR DESCRIPTION
Per Alicja's request. Experimentalists (for now) are calculating approach to social by hand, and automatically creating a separate directory with all activity files will speed up their analysis.