### PR TITLE
dynamic interaction sum added

### DIFF
--- a/pyEcoHAB/following.py
+++ b/pyEcoHAB/following.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import
 import random
 import os
 import numpy as np
+from collections import OrderedDict
 
 from . import utility_functions as utils
 from .write_to_file import save_single_histograms
@@ -16,7 +17,7 @@ from .plotting_functions import pooled_hists
 from .plotting_functions import make_histograms_for_every_mouse
 from .plotting_functions import pooled_hists_for_every_mouse
 from .plotting_functions import single_histogram_figures
-from collections import OrderedDict
+
 
 
 def insert_interval(candidate_t_start, interval,

--- a/pyEcoHAB/following.py
+++ b/pyEcoHAB/following.py
@@ -10,11 +10,13 @@ from .write_to_file import write_csv_rasters
 from .write_to_file import write_binned_data
 from .write_to_file import write_interpair_intervals
 from .write_to_file import write_bootstrap_results
+from .write_to_file import write_sum_data
 from .plotting_functions import single_in_cohort_soc_plot, make_RasterPlot
 from .plotting_functions import pooled_hists
 from .plotting_functions import make_histograms_for_every_mouse
 from .plotting_functions import pooled_hists_for_every_mouse
 from .plotting_functions import single_histogram_figures
+from collections import OrderedDict
 
 
 def insert_interval(candidate_t_start, interval,
@@ -357,8 +359,17 @@ def get_dynamic_interactions(ecohab_data, timeline, N, binsize=12*3600,
                                     "durations_dynamic_interactions",
                                     "rasters",
                                     "bin_%s" % binsize)
+
+    mouse_leading_sum = OrderedDict()
+    mouse_following_sum = OrderedDict()
+    mouse_leading_sum_exp = OrderedDict()
+    mouse_following_sum_exp = OrderedDict()
     for idx_phase, ph in enumerate(all_phases):
         new_phase = phases[idx_phase]
+        mouse_leading_sum[ph] = OrderedDict()
+        mouse_following_sum[ph] = OrderedDict()
+        mouse_leading_sum_exp[ph] = OrderedDict()
+        mouse_following_sum_exp[ph] = OrderedDict()
         for i, lab in enumerate(bin_labels):
             t_start, t_stop = times[ph][lab]
             directions_dict = data[ph][lab]
@@ -379,6 +390,12 @@ def get_dynamic_interactions(ecohab_data, timeline, N, binsize=12*3600,
                                                  save_figures=save_figures)
             following_exp[ph][lab], time_together_exp[ph][lab] = out_expected
             add_intervals(interval_details, phase_intervals1)
+
+        mouse_leading_sum[ph] = utils.sum_per_mouse(following, mice, bin_labels, ph, "leader", True)
+        mouse_following_sum[ph] = utils.sum_per_mouse(following, mice, bin_labels, ph, "follower", True)
+
+        mouse_leading_sum_exp[ph] = utils.sum_per_mouse(following_exp, mice, bin_labels, ph, "leader", True)
+        mouse_following_sum_exp[ph] = utils.sum_per_mouse(following_exp, mice, bin_labels, ph, "follower", True)
 
         write_binned_data(following[ph],
                           'dynamic_interactions',
@@ -559,6 +576,17 @@ def get_dynamic_interactions(ecohab_data, timeline, N, binsize=12*3600,
                               fname_excess, delimiter=delimiter,
                               symmetrical=False)
 
+    write_sum_data(mouse_leading_sum, "mouse_leading_sum", mice, bin_labels, all_phases, res_dir,
+                   raster_dir_add, prefix, additional_info="ALL", delimiter=";", bool_bins=False)
+    write_sum_data(mouse_following_sum, "mouse_following_sum", mice, bin_labels, all_phases, res_dir,
+                   raster_dir_add, prefix, additional_info="ALL",delimiter=";", bool_bins=False)
+
+    write_sum_data(mouse_leading_sum_exp, "mouse_leading_sum_exp", mice, bin_labels, all_phases, res_dir,
+                   raster_dir_add, prefix, additional_info="ALL", delimiter=";", bool_bins=False)
+    write_sum_data(mouse_following_sum_exp, "mouse_following_sum_exp", mice, bin_labels, all_phases, res_dir,
+                   raster_dir_add, prefix, additional_info="ALL", delimiter=";", bool_bins=False)
+
+
     if isinstance(binsize, int) or isinstance(binsize, float):
         if binsize == 43200:
             write_csv_rasters(mice,
@@ -614,6 +642,7 @@ def get_dynamic_interactions(ecohab_data, timeline, N, binsize=12*3600,
                          other_excess_hist,
                          prefix,
                          additional_info=add_info_mice)
+
 
     if save_times_following:
         make_histograms_for_every_mouse(interval_details,

--- a/pyEcoHAB/incohort_sociability.py
+++ b/pyEcoHAB/incohort_sociability.py
@@ -285,7 +285,7 @@ def get_incohort_sociability(ecohab_data, timeline, binsize, res_dir="",
                                         full_results_exp[ph])
 
         reflected_excess_time = utils.diagonal_reflection(excess_time, mice, bin_labels)
-        excess_time_per_mouse[ph] = utils.sum_per_mouse(reflected_excess_time,mice, bin_labels)
+        excess_time_per_mouse[ph] = utils.sum_per_mouse(reflected_excess_time, mice, bin_labels, ph, "sum_per_mouse", False)
 
 
 
@@ -406,6 +406,6 @@ def get_incohort_sociability(ecohab_data, timeline, binsize, res_dir="",
                             symmetrical=True)
 
         write_sum_data(excess_time_per_mouse, 'excess_incohort_sociability_per_mouse', mice, bin_labels, all_phases,
-                       res_dir, out_dir_hist, prefix, additional_info=add_info_mice, delimiter=delimiter)
+                       res_dir, out_dir_hist, prefix, additional_info=add_info_mice, delimiter=delimiter, bool_bins=True)
 
     return full_results, full_results_exp

--- a/pyEcoHAB/tests/test_utility_functions.py
+++ b/pyEcoHAB/tests/test_utility_functions.py
@@ -2181,6 +2181,7 @@ class TestPrepareBinnedRegistrations(unittest.TestCase):
 class TestPrepareForSumming(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        cls.phase = ['EMPTY 1 dark']
         cls.binsizes = [1800, 3600, 1.5 * 3600, 7200, 14400, 43200]
         cls.bins = 12 * 3600 / cls.binsizes[4]
         cls.bin_labels = []
@@ -2192,35 +2193,43 @@ class TestPrepareForSumming(unittest.TestCase):
         cls.test_excess = OrderedDict()
         cls.test_sum = OrderedDict()
 
-        for key1 in cls.bin_labels:
+        for key1 in cls.phase:
             cls.excess[key1] = OrderedDict()
             cls.test_excess[key1] = OrderedDict()
             cls.test_sum[key1] = OrderedDict()
-            for key2 in cls.mice:
-
+            for key2 in cls.bin_labels:
                 cls.excess[key1][key2] = OrderedDict()
                 cls.test_excess[key1][key2] = OrderedDict()
-                cls.test_sum[key1][key2] = 0.08
+                cls.test_sum[key1][key2] = OrderedDict()
                 for key3 in cls.mice:
-                    cls.excess[key1][key2][key3] = 0.00
-                    cls.test_excess[key1][key2][key3] = 0.04
-                    if key2 == key3:
-                        cls.test_excess[key1][key2][key3] = 0.00
-                    elif key2 < key3:
-                        cls.excess[key1][key2][key3] = 0.04
+                    cls.excess[key1][key2][key3] = OrderedDict()
+                    cls.test_excess[key1][key2][key3] = OrderedDict()
+                    cls.test_sum[key1][key2][key3] = 0.08
+                    for key4 in cls.mice:
+                        cls.excess[key1][key2][key3][key4] = 0.00
+                        cls.test_excess[key1][key2][key3][key4] = 0.04
+                        if key3 == key4:
+                            cls.test_excess[key1][key2][key3][key4] = 0.00
+                        elif key3 < key4:
+                            cls.excess[key1][key2][key3][key4] = 0.04
 
     def test_diagonal_reflection_of_matrix(self):
 
-        reflected_excess_time = uf.diagonal_reflection(self.excess, self.mice, self.bin_labels)
-        self.assertEqual(reflected_excess_time, self.test_excess, "False, diagonal reflection test failed")
+        reflected_excess_time = uf.diagonal_reflection(self.excess[self.phase[0]], self.mice, self.bin_labels)
+        self.assertEqual(reflected_excess_time, self.test_excess[self.phase[0]], "False, diagonal reflection test failed")
         return (reflected_excess_time)
 
+    def test_sum_per_mouse_no_phase(self):
+        sum_excess_time = uf.sum_per_mouse(self.test_diagonal_reflection_of_matrix(),
+                                           self.mice, self.bin_labels, self.phase[0], "sum_per_mouse", False)
+        self.assertEqual(sum_excess_time, self.test_sum[self.phase[0]], "False, sum test failed")
 
-    def test_sum_per_mouse(self):
-        sum_excess_time = uf.sum_per_mouse(self.test_diagonal_reflection_of_matrix(), self.mice, self.bin_labels)
-        self.assertEqual(sum_excess_time, self.test_sum, "False, sum test failed")
-
-
+    def test_sum_per_mouse_phase(self):
+        sum_time = OrderedDict()
+        sum_time[self.phase[0]] = self.test_diagonal_reflection_of_matrix()
+        sum_time[self.phase[0]] = uf.sum_per_mouse(sum_time, self.mice, self.bin_labels,
+                                       self.phase[0], "leader", True)
+        self.assertEqual(sum_time, self.test_sum, "False, sum test with phase failed")
 
 
 if __name__ == '__main__':

--- a/pyEcoHAB/utility_functions.py
+++ b/pyEcoHAB/utility_functions.py
@@ -670,14 +670,27 @@ def diagonal_reflection(matrix_data, mice, binlabels):
     return(matrix_data)
 
 
-def sum_per_mouse(data, mice, binlabels):
-    sum_time = OrderedDict()
+def sum_per_mouse(data, mice, binlabels, phase, position, boolPhase=bool):
+    sum_value = OrderedDict()
     for bin in binlabels:
-        sum_time[bin] = OrderedDict()
+        sum_value[bin] = OrderedDict()
         for mouse1 in mice:
-            sum_time[bin][mouse1] = OrderedDict()
-            sum_time_per_mouse = 0
+            sum_value[bin][mouse1] = 0
             for mouse2 in mice:
-                sum_time_per_mouse += data[bin][mouse1][mouse2]
-            sum_time[bin][mouse1] = sum_time_per_mouse
-    return(sum_time)
+                if mouse1 == mouse2:
+                    continue
+                else:
+                    if (position == "leader" or position == "sum_per_mouse"):
+                        if boolPhase == True:
+                            sum_value[bin][mouse1] += data[phase][bin][mouse1][mouse2]
+                        else:
+                            sum_value[bin][mouse1] += data[bin][mouse1][mouse2]
+                    elif (position == "follower"):
+                        if boolPhase == True:
+                            sum_value[bin][mouse1] += data[phase][bin][mouse2][mouse1]
+                        else:
+                            sum_value[bin][mouse1] += data[bin][mouse2][mouse1]
+                    else:
+                        print("Position value is invalid, please check it")
+                        exit()
+    return(sum_value)

--- a/pyEcoHAB/write_to_file.py
+++ b/pyEcoHAB/write_to_file.py
@@ -344,7 +344,7 @@ def save_antenna_transitions(transition_times,
 
 def write_sum_data(data, fname, mice, bin_labels, phases,
                       path, target_dir, prefix, additional_info="",
-                      delimiter=";"):
+                      delimiter=";", bool_bins=bool):
     new_path = os.path.join(path, target_dir, "data")
     fname = os.path.join(new_path, '%s_%s_%s.csv' % (fname, prefix, additional_info))
     if not os.path.exists(new_path):
@@ -354,11 +354,15 @@ def write_sum_data(data, fname, mice, bin_labels, phases,
     header = 'mouse'
 
     for phase in phases:
-        for bin in bin_labels:
-            header += delimiter + str(bin/3600) + "h "+ str(phase)
+        if bool_bins == True:
+            for bin in bin_labels:
+                header += delimiter + str(bin/3600) + "h "+ str(phase)
+        else:
+            header += delimiter + str(phase)
     header += '\n'
     f.write(header)
-
+    phase = phases[0]
+    bin = bin_labels[0]
     for mouse_label in data[phase][bin].keys():
         f.write(mouse_label + delimiter)
         for phase in phases:


### PR DESCRIPTION
This change adds calculation of total following and total leading for each mouse for each time bin.  sum_per_mouse from utility_functions.py is reused. Total following and leading is calculated and saved to text files for both measured and expected values. Per Anna Bryksa's reqest.