### PR TITLE
Generate config files

### DIFF
--- a/src/pyEcoHAB/Timeline.py
+++ b/src/pyEcoHAB/Timeline.py
@@ -146,3 +146,36 @@ class Timeline(RawConfigParser, matplotlib.ticker.Formatter):
         ax.get_figure().autofmt_xdate()
         plt.title(self.path)
         plt.draw()
+
+
+def generate_timeline(data_directory, dark_beginning="12:00",
+                      first_phase="dark", dark_length=12, light_length=12,
+                      phase_name="EMPTY"):
+    """
+    Automatically generate timeline of an EcoHAB experiment
+
+    This function will calculate phases beginnings and endings and generate 
+    the timeline of the experiment with phases named phase_name number phase_type.
+    The file will be save in data_directory. If the beginning of 
+    the dark phase is not provided, 12:00 will be used. Dark and light phase 
+    lengths will be used to calculate begginings and endings of each phase.
+    Phase lengths can be specified, otherwise it is assumed that dark and light
+    phase are 12 h long.
+    
+
+    Args:
+       data_directory: str
+           path to the directory containing experiment data files
+       dark_beginning: str
+           At what time do the dark phases begin. Default: 12:00
+       first_phase: str
+           What phase is the first: dark or light. Default: dark
+       dark_length: float
+           Length of the dark phase (in hours). Default: 12 
+       light_length: float
+           Length of the light phase (in hours). Default: 12 
+       phase_name: str
+           name of all the phases. Default: EMPTY. 
+           Consecutive phases will be named: EMPTY 1 dark, EMPTY 1 light,
+           EMPTY 2 dark ...
+    """

--- a/src/pyEcoHAB/Timeline.py
+++ b/src/pyEcoHAB/Timeline.py
@@ -22,7 +22,7 @@ import matplotlib.dates as mpd
 import matplotlib.pyplot as plt
 from pyEcoHAB import utility_functions as uf
 from pyEcoHAB.utils import for_loading as fl
-
+from pyEcoHAB.utils import temporal as temp
 
 
 
@@ -147,7 +147,8 @@ class Timeline(ConfigParser, matplotlib.ticker.Formatter):
         plt.title(self.path)
         plt.draw()
 
-
+ 
+        
 def generate_timeline(data_directory, dark_beginning="12:00",
                       first_phase="dark", dark_length=12, light_length=12,
                       phase_name="EMPTY"):
@@ -184,17 +185,17 @@ def generate_timeline(data_directory, dark_beginning="12:00",
     filenames = sorted(fl.get_filenames(data_directory))
     #find beginning of the experiment
     first_day = filenames[0].split("_")[0]
-    dark_beg = time.strptime(dark_beginning, "%H:%M")
     light_duration = datetime.timedelta(hours=light_length)
-    dark_duration = datetime.timedelta(hours=dark_lenght)
-    light_beg = dark_beg + dark_duration
+    dark_duration = datetime.timedelta(hours=dark_length)
+    light_beginning = temp.find_light_beginning(dark_beginning,
+                                                dark_length)
     if first_phase.lower() == "dark":
         str_date = "%s%s UTC" % (first_day, dark_beginning)
-        start_date = time.strptime(str_date, "%Y%m%d%H:%M %Z")
+
     elif first_phase.lower() == "light":
-        start_date = time.strptime("%s UTC" % first_day, "%Y%m%d %Z")
+        str_date = "%s%s UTC" % (first_day, light_beginning)
         
-        
+    start_date = time.strptime(str_date, "%Y%m%d%H:%M %Z")        
     
     
     

--- a/src/pyEcoHAB/Timeline.py
+++ b/src/pyEcoHAB/Timeline.py
@@ -184,19 +184,32 @@ def generate_timeline(data_directory, dark_beginning="12:00",
     #find files
     filenames = sorted(fl.get_filenames(data_directory))
     #find beginning of the experiment
-    first_day = filenames[0].split("_")[0]
-    light_duration = datetime.timedelta(hours=light_length)
-    dark_duration = datetime.timedelta(hours=dark_length)
+    first_day, last_day = temp.find_first_last(filenames)
     light_beginning = temp.find_light_beginning(dark_beginning,
                                                 dark_length)
+    light_duration = datetime.timedelta(hours=light_length)
+    dark_duration = datetime.timedelta(hours=dark_length)
     if first_phase.lower() == "dark":
         str_date = "%s%s UTC" % (first_day, dark_beginning)
 
     elif first_phase.lower() == "light":
         str_date = "%s%s UTC" % (first_day, light_beginning)
-        
+    
     start_date = time.strptime(str_date, "%Y%m%d%H:%M %Z")        
+    i = 1
+    current_phase = first_phase
+    while True:
+        #current phase name
+        full_phase_name ="%s %d %s" % (phase_name, i, current_phase)
+        if current_phase.lower() == "light":
+            end_date = start_date + light_duration
+        else:
+            end_date = start_date + dark_duration
+        
+        
     
-    
-    
-    
+        if current_phase.lower() == "light":
+            i = i+1
+            current_phase = "dark"
+        else:
+            current phase = "light"

--- a/src/pyEcoHAB/Timeline.py
+++ b/src/pyEcoHAB/Timeline.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # -*- encoding: utf-8 -*-
-from __future__ import division, absolute_import, print_function
 """
 Timeline.py
 
@@ -8,7 +7,8 @@ Created by Szymon Łęski on 2013-02-19.
 
 """
 import os
-from configparser import RawConfigParser, NoSectionError
+from configparser import ConfigParser, NoSectionError
+import glob
 import sys
 import time
 import calendar
@@ -28,7 +28,7 @@ from pyEcoHAB.utils import for_loading as fl
 
 
 
-class Timeline(RawConfigParser, matplotlib.ticker.Formatter):
+class Timeline(ConfigParser, matplotlib.ticker.Formatter):
     """Read in the temporal config of the experiment
      (timeline of the experiment).
 
@@ -50,7 +50,7 @@ class Timeline(RawConfigParser, matplotlib.ticker.Formatter):
 
     """
     def __init__(self, path, fname=None):
-        RawConfigParser.__init__(self)
+        ConfigParser.__init__(self)
         self.path = path
         if fname is None:
             if os.path.isfile(path):
@@ -179,3 +179,23 @@ def generate_timeline(data_directory, dark_beginning="12:00",
            Consecutive phases will be named: EMPTY 1 dark, EMPTY 1 light,
            EMPTY 2 dark ...
     """
+    config = ConfigParser()
+    #find files
+    filenames = sorted(fl.get_filenames(data_directory))
+    #find beginning of the experiment
+    first_day = filenames[0].split("_")[0]
+    dark_beg = time.strptime(dark_beginning, "%H:%M")
+    light_duration = datetime.timedelta(hours=light_length)
+    dark_duration = datetime.timedelta(hours=dark_lenght)
+    light_beg = dark_beg + dark_duration
+    if first_phase.lower() == "dark":
+        str_date = "%s%s UTC" % (first_day, dark_beginning)
+        start_date = time.strptime(str_date, "%Y%m%d%H:%M %Z")
+    elif first_phase.lower() == "light":
+        start_date = time.strptime("%s UTC" % first_day, "%Y%m%d %Z")
+        
+        
+    
+    
+    
+    

--- a/src/pyEcoHAB/utils/temporal.py
+++ b/src/pyEcoHAB/utils/temporal.py
@@ -1,0 +1,22 @@
+import time
+
+def convert_int_to_time(number):
+    if number < 10:
+        return "0%d"%number
+    return "%d"%number
+
+def find_light_beginning(dark_beg, dark_len):
+    hours, mins = dark_beg.split(":")
+    d_hours = int(hours)
+    d_mins = int(mins)
+    #dark len in h
+    add_to_h = 0
+    new_mins = int((dark_len - int(dark_len))*60) + d_mins
+    if new_mins > 60:
+        new_mins = new_mins-60
+        add_to_h = 1
+    new_hours = d_hours + int(dark_len) + add_to_h
+    if new_hours >= 24:
+        new_hours = new_hours - 24
+    return "%s:%s" % (convert_int_to_time(new_hours),
+                      convert_int_to_time(new_mins))  

--- a/src/pyEcoHAB/utils/temporal.py
+++ b/src/pyEcoHAB/utils/temporal.py
@@ -1,4 +1,5 @@
-import time
+from datetime import datetime, timedelta
+from pyEcoHAB.utils import for_loading as fl
 
 def convert_int_to_time(number):
     if number < 10:
@@ -22,4 +23,108 @@ def find_light_beginning(dark_beg, dark_len):
                       convert_int_to_time(new_mins))  
 
 def find_first_last(filename_list):
-    return filename_list[0].split("_")[0], filenames[-1].split("_"][0]
+    first = filename_list[0].split("_")[0]
+    last = filename_list[-1].split(".txt")[0] + " UTC"
+    return first, last
+
+
+def last_day_to_datetime(last_day):
+    return  datetime.strptime(last_day, "%Y%m%d_%H%M%S %Z")
+
+
+def strtime_to_datetime(text_time):
+    return datetime.strptime(text_time, "%Y%m%d%H:%M %Z")
+
+
+def get_date(date_obj):
+    return date_obj.strftime("%d.%m.%Y")
+
+
+def get_time(date_obj):
+    return date_obj.strftime("%H:%M")
+
+
+def make_config_entry(start_date, end_date):
+    return {
+        "startdate": get_date(start_date),
+        "starttime": get_time(start_date),
+        "enddate": get_date(end_date),
+        "endtime": get_time(end_date),
+        }
+
+
+def gen_timeline(data_directory, dark_beginning="12:00",
+                 first_phase="dark", dark_length=12,
+                 light_length=12,
+                 phase_name="EMPTY"):
+    """
+    Automatically generate timeline of an EcoHAB experiment
+
+    This function will calculate phases beginnings and endings and generate 
+    the timeline of the experiment with phases named phase_name number phase_type.
+    The file will be save in data_directory. If the beginning of 
+    the dark phase is not provided, 12:00 will be used. Dark and light phase 
+    lengths will be used to calculate begginings and endings of each phase.
+    Phase lengths can be specified, otherwise it is assumed that dark and light
+    phase are 12 h long.
+    
+
+    Args:
+       data_directory: str
+           path to the directory containing experiment data files
+       dark_beginning: str
+           At what time do the dark phases begin. Default: 12:00
+       first_phase: str
+           What phase is the first: dark or light. Default: dark
+       dark_length: float
+           Length of the dark phase (in hours). Default: 12 
+       light_length: float
+           Length of the light phase (in hours). Default: 12 
+       phase_name: str
+           name of all the phases. Default: EMPTY. 
+           Consecutive phases will be named: EMPTY 1 dark, EMPTY 1 light,
+           EMPTY 2 dark ...
+    """
+    config = {}
+    #find files
+    filenames = sorted(fl.get_filenames(data_directory))
+    #find beginning of the experiment
+    first_day, last_day = find_first_last(filenames)
+    light_beginning = find_light_beginning(dark_beginning,
+                                           dark_length)
+    light_duration = timedelta(hours=light_length)
+    dark_duration = timedelta(hours=dark_length)
+    
+    if first_phase.lower() == "dark":
+        str_date = "%s%s UTC" % (first_day, dark_beginning)
+
+    elif first_phase.lower() == "light":
+        str_date = "%s%s UTC" % (first_day, light_beginning)
+    
+    start_date = strtime_to_datetime(str_date)
+    total_beg = strtime_to_datetime(str_date)
+    total_end = last_day_to_datetime(last_day)
+    i = 1
+    current_phase = first_phase
+    while True:
+        #current phase name
+        full_phase_name ="%s %d %s" % (phase_name, i, current_phase)
+        
+        if current_phase.lower() == "light":
+            end_date = start_date + light_duration
+        else:
+            end_date = start_date + dark_duration
+        config[full_phase_name] = make_config_entry(start_date,
+                                                    end_date)
+    
+        if current_phase.lower() == "light":
+            i = i+1
+            current_phase = "dark"
+        else:
+            current_phase = "light"
+        start_date = end_date
+        if start_date > total_end:
+            config["ALL"] = make_config_entry(total_beg,
+                                              end_date)
+            break
+    return config

--- a/src/pyEcoHAB/utils/temporal.py
+++ b/src/pyEcoHAB/utils/temporal.py
@@ -20,3 +20,6 @@ def find_light_beginning(dark_beg, dark_len):
         new_hours = new_hours - 24
     return "%s:%s" % (convert_int_to_time(new_hours),
                       convert_int_to_time(new_mins))  
+
+def find_first_last(filename_list):
+    return filename_list[0].split("_")[0], filenames[-1].split("_"][0]

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,35 @@
+import unittest
+import pyEcoHAB.utils.temporal as ut
+
+class TestConvertIntsToTime(unittest.TestCase):
+    def test_1(self):
+        self.assertEqual(ut.convert_int_to_time(1), "01")
+
+    def test_2(self):
+        self.assertEqual(ut.convert_int_to_time(0), "00")
+
+    def test_3(self):
+        self.assertEqual(ut.convert_int_to_time(31), "31")
+
+class TestFindLightBeginnig(unittest.TestCase):
+    def test_1(self):
+        dark_beg = "12:00"
+        dark_len = 12
+        self.assertEqual(ut.find_light_beginning(dark_beg, dark_len),
+                         "00:00")
+        
+    def test_2(self):
+        dark_beg = "12:40"
+        dark_len = 12.5
+        self.assertEqual(ut.find_light_beginning(dark_beg, dark_len),
+                         "01:10")
+
+
+    def test_3(self):
+        dark_beg = "00:00"
+        dark_len = 12.5
+        self.assertEqual(ut.find_light_beginning(dark_beg, dark_len),
+                         "12:30")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,5 +1,11 @@
 import unittest
+import os
+from datetime import datetime, tzinfo, date, time
+from configparser import ConfigParser
+
 import pyEcoHAB.utils.temporal as ut
+from pyEcoHAB.utils import for_loading as fl
+from pyEcoHAB import sample_data
 
 class TestConvertIntsToTime(unittest.TestCase):
     def test_1(self):
@@ -24,12 +30,115 @@ class TestFindLightBeginnig(unittest.TestCase):
         self.assertEqual(ut.find_light_beginning(dark_beg, dark_len),
                          "01:10")
 
-
     def test_3(self):
         dark_beg = "00:00"
         dark_len = 12.5
         self.assertEqual(ut.find_light_beginning(dark_beg, dark_len),
                          "12:30")
 
+
+class DealWithDates(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.filenames = sorted(fl.get_filenames(sample_data))
+        cls.first, cls.last = ut.find_first_last(cls.filenames)
+        
+    def test_first(self):
+        self.assertEqual(self.first, "20140616")
+
+    def test_last(self):
+        self.assertEqual(self.last, "20140619_110000 UTC")
+
+    def test_last_day_to_datetime(self):
+        last = ut.last_day_to_datetime(self.last)
+        expected = datetime(year=2014, month=6, day=19, hour=11,
+                            tzinfo=tzinfo("UTF"))
+    
+    def test_strtime_to_datetime(self):
+        measured = ut.strtime_to_datetime("%s12:00 UTC" % self.first)
+        expected = datetime(year=2014, month=6, day=16, hour=12,
+                            tzinfo=tzinfo("UTF"))
+
+    def test_get_date(self):
+        self.assertEqual(ut.get_date(date(day=16, month=6, year=2014)),
+                         "16.06.2014")
+
+    def test_get_time(self):
+        self.assertEqual(ut.get_time(time(hour=12)), "12:00")
+
+
+    def generate_entry(self):
+        first = datetime(year=2014, month=6, day=19, hour=12,
+                         tzinfo=tzinfo("UTF"))
+        last = datetime(year=2014, month=6, day=20, hour=00,
+                         tzinfo=tzinfo("UTF"))
+        out = ut.make_cofig_entry(first, last)
+        expected = {"startdate": "2014.06.19",
+                    "starttime": "12:00",
+                    "enddate": "2014.06.20",
+                    "endtime": "00:00"}
+        self.assertEqual(out, expected)
+
+
+class TestGenerateTimeline(unittest.TestCase):
+    def test(self):
+        config_gen = ut.gen_timeline(sample_data,
+                                     dark_beginning="12:00",
+                                     first_phase="dark",
+                                     dark_length=12,
+                                     light_length=12,
+                                     phase_name="EMPTY")
+        config_exp = {
+            "EMPTY 1 dark": {
+                "startdate": "16.06.2014",
+                "starttime": "12:00",
+                "enddate": "17.06.2014",
+                "endtime": "00:00",
+
+            },
+            "EMPTY 1 light": {
+                "startdate": "17.06.2014",
+                "starttime": "00:00",
+                "enddate": "17.06.2014",
+                "endtime": "12:00",
+                
+            },
+            "EMPTY 2 dark": {
+                "startdate": "17.06.2014",
+                "starttime": "12:00",
+                "enddate": "18.06.2014",
+                "endtime": "00:00",
+
+            },
+            "EMPTY 2 light": {
+                "startdate": "18.06.2014",
+                "starttime": "00:00",
+                "enddate": "18.06.2014",
+                "endtime": "12:00",
+
+            },
+            "EMPTY 3 dark": {
+                "startdate": "18.06.2014",
+                "starttime": "12:00",
+                "enddate": "19.06.2014",
+                "endtime": "00:00",
+
+            },
+            "EMPTY 3 light": {
+                "startdate": "19.06.2014",
+                "starttime": "00:00",
+                "enddate": "19.06.2014",
+                "endtime": "12:00",
+
+            },
+            "ALL": {
+                "startdate": "16.06.2014",
+                "starttime": "12:00",
+                "enddate": "19.06.2014",
+                "endtime": "12:00",}
+        }
+        self.assertEqual(config_exp, config_gen)
+
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is for my convenience: researchers sometimes forget to provide timeline of the experiment, functionality added here will generate a very perfunctory temporal configuration file that can later be edited.